### PR TITLE
fix docker hub auto build error

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -15,6 +15,7 @@ RUN apt-get install -y \
 ADD Makefile .
 RUN make setup
 
-ADD kong-plugin-api-transformer-*.rockspec .
+ADD kong-plugin-api-transformer-scm-0.rockspec .
+ADD kong-plugin-api-transformer-0.1.0-0.rockspec .
 
 ENV LUA_PATH="/api-transformer/?.lua;;"


### PR DESCRIPTION
```
Step 6/7 : ADD kong-plugin-api-transformer-*.rockspec .
When using ADD with more than one source file, the destination must be a directory and end with a /
```